### PR TITLE
Adds a small indicator badge to profile

### DIFF
--- a/src/components/profile/NetworkIndicatorIcon.js
+++ b/src/components/profile/NetworkIndicatorIcon.js
@@ -1,0 +1,33 @@
+import React from 'react';
+
+const mainNetSettings = { netType: 'Mainnet', color: 'bg-success' };
+const testNetSettings = { netType: 'Testnet', color: 'bg-warning' };
+
+const getNetwork = chainSuffix => {
+  const net = chainSuffix.split('=')[1];
+
+  const netMap = new Map();
+  netMap.set('testnet', testNetSettings);
+  netMap.set('mainnet', mainNetSettings);
+
+  return netMap.get(net) || mainNetSettings;
+};
+
+const NetworkIndicatorIcon = ({ chainSuffix }) => {
+  const network = getNetwork(chainSuffix);
+  return (
+    <i
+      className="bi bi-person-circle me-2 position-relative"
+      data-toggle="tooltip"
+      data-placement="top"
+      title={`You are on the ${network.netType} network`}
+    >
+      <span
+        className={`position-absolute top-0 start-100 translate-middle p-2 ${network.color} border border-light rounded-circle`}
+      >
+        <span className="visually-hidden">{network.netType}</span>
+      </span>
+    </i>
+  );
+};
+export default NetworkIndicatorIcon;

--- a/src/components/profile/NetworkIndicatorIcon.js
+++ b/src/components/profile/NetworkIndicatorIcon.js
@@ -23,7 +23,7 @@ const NetworkIndicatorIcon = ({ chainSuffix }) => {
       title={`You are on the ${network.netType} network`}
     >
       <span
-        className={`position-absolute top-0 start-100 translate-middle p-2 ${network.color} border border-light rounded-circle`}
+        className={`position-absolute transform-network-indicator p-1 ${network.color} border-0 rounded-circle`}
       >
         <span className="visually-hidden">{network.netType}</span>
       </span>

--- a/src/components/profile/ProfileFull.js
+++ b/src/components/profile/ProfileFull.js
@@ -6,11 +6,10 @@ import { currentCity, stxBalanceAtom } from '../../store/common';
 import SelectCity from '../common/SelectCity';
 import { userSessionState } from '../../lib/auth';
 import { useStxAddresses } from '../../lib/hooks';
-import { ustxToStx } from '../../lib/stacks';
+import { ustxToStx, chainSuffix } from '../../lib/stacks';
 import LoadingSpinner from '../common/LoadingSpinner';
 import { testnet } from '../../lib/stacks';
 import NetworkIndicatorIcon from './NetworkIndicatorIcon';
-import { chainSuffix } from '../../lib/constants';
 
 export function ProfileFull(props) {
   const [userSession] = useAtom(userSessionState);
@@ -65,7 +64,7 @@ export function ProfileFull(props) {
     >
       <div className="offcanvas-header">
         <h5 className="offcanvas-title" id="offcanvasProfileLabel">
-          <NetworkIndicatorIcon chainSuffix={chainSuffix}/>
+          <NetworkIndicatorIcon chainSuffix={chainSuffix} />
           {ownerStxAddress ? <Address addr={ownerStxAddress} /> : 'Profile'}{' '}
         </h5>
         <button

--- a/src/components/profile/ProfileFull.js
+++ b/src/components/profile/ProfileFull.js
@@ -9,6 +9,8 @@ import { useStxAddresses } from '../../lib/hooks';
 import { ustxToStx } from '../../lib/stacks';
 import LoadingSpinner from '../common/LoadingSpinner';
 import { testnet } from '../../lib/stacks';
+import NetworkIndicatorIcon from './NetworkIndicatorIcon';
+import { chainSuffix } from '../../lib/constants';
 
 export function ProfileFull(props) {
   const [userSession] = useAtom(userSessionState);
@@ -63,7 +65,7 @@ export function ProfileFull(props) {
     >
       <div className="offcanvas-header">
         <h5 className="offcanvas-title" id="offcanvasProfileLabel">
-          <i className="bi bi-person-circle me-2" />
+          <NetworkIndicatorIcon chainSuffix={chainSuffix}/>
           {ownerStxAddress ? <Address addr={ownerStxAddress} /> : 'Profile'}{' '}
         </h5>
         <button

--- a/src/components/profile/ProfileSmall.js
+++ b/src/components/profile/ProfileSmall.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { ProfileFull } from './ProfileFull';
 import { useStxAddresses } from '../../lib/hooks';
 import { Address } from '../Address';
+import NetworkIndicatorIcon from './NetworkIndicatorIcon';
+import { chainSuffix } from '../../lib/constants';
 
 export function ProfileSmall(props) {
   const { ownerStxAddress } = useStxAddresses(props.userSession);
@@ -16,7 +18,7 @@ export function ProfileSmall(props) {
           role="button"
           aria-controls="offcanvasProfile"
         >
-          <i className="bi bi-person-circle me-2" />
+          <NetworkIndicatorIcon chainSuffix={chainSuffix}/>
           {ownerStxAddress ? <Address addr={ownerStxAddress} /> : 'Profile'}
         </a>
 

--- a/src/lib/stacks.js
+++ b/src/lib/stacks.js
@@ -1,6 +1,10 @@
 import { StacksMainnet, StacksTestnet } from '@stacks/network';
 
 export const testnet = window.location.search.includes('chain=testnet');
+export const localMocknet = !testnet && window.location.search.includes('mocknet=local');
+export const mainnet =
+  (!testnet && !localMocknet) || window.location.search.includes('chain=mainnet');
+export const chainSuffix = `?chain=${mainnet ? 'mainnet' : testnet ? 'testnet' : 'mocknet'}`;
 
 export const CITYCOIN_DEPLOYER = 'SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27';
 export const CITYCOIN_VRF = 'citycoin-vrf';

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -117,7 +117,7 @@ inspect {
   top: 115px;
 }
 
-/* positions small indicator circle on the person-circle icon in Profile */
+/* Positions small indicator circle on the person-circle icon in profile */
 .transform-network-indicator {
   left: 14px;
   top: 1.5px;

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -116,3 +116,9 @@ inspect {
 .sticky-top-profile {
   top: 115px;
 }
+
+/* positions small indicator circle on the person-circle icon in Profile */
+.transform-network-indicator {
+  left: 14px;
+  top: 1.5px;
+}


### PR DESCRIPTION
This PR attempts to provide a solution for issue  [#19](https://github.com/citycoins/citycoin-ui/issues/19). 

As discussed in the issue, the indicator badge will change colors if the network changes. As discussed in the issue the Mainnet is signified by a green indicator, while the Testnet is indicated by an orange indicator. I tried to keep in mind that there may be future requirements for different indicators on different networks, although for now I only added the two. If needed the colors can easily be changed as well, but for now went with "default" bootstrap colors. 
