### PR TITLE
Adds link to testnet faucet

### DIFF
--- a/src/components/profile/ProfileFull.js
+++ b/src/components/profile/ProfileFull.js
@@ -9,6 +9,7 @@ import { useStxAddresses } from '../../lib/hooks';
 import { ustxToStx } from '../../lib/stacks';
 import LoadingSpinner from '../common/LoadingSpinner';
 import { testnet } from '../../lib/stacks';
+import { TESTNET_FAUCET_URL } from '../../lib/constants';
 
 export function ProfileFull(props) {
   const [userSession] = useAtom(userSessionState);
@@ -104,6 +105,18 @@ export function ProfileFull(props) {
                 <i className="bi bi-box-arrow-up-right"></i> View Address on Explorer
               </a>
             </li>
+            {testnet && (
+              <li>
+                <a
+                  rel="noreferrer"
+                  href={TESTNET_FAUCET_URL}
+                  className="dropdown-item"
+                  target="_blank"
+                >
+                  <i className="bi bi-box-arrow-up-right" /> STX Faucet
+                </a>
+              </li>
+            )}
             <li>
               <a
                 className="dropdown-item"

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -48,7 +48,7 @@ export const STACKS_API_WS_URL = localNode
 export const STACKS_API_V2_INFO = `${STACKS_API_URL}/v2/info`;
 export const STACKS_API_ACCOUNTS_URL = `${STACKS_API_URL}/v2/accounts`;
 export const STACKS_API_FEE_URL = `${STACKS_API_URL}/v2/fees/transfer`;
-export const TESTNET_FAUCET_URL = 'https://explorer.stacks.co/sandbox/faucet';
+export const TESTNET_FAUCET_URL = 'https://explorer.stacks.co/sandbox/faucet?chain=testnet';
 
 export const NETWORK = mainnet ? new StacksMainnet() : new StacksTestnet();
 NETWORK.coreApiUrl = STACKS_API_URL;

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -48,6 +48,7 @@ export const STACKS_API_WS_URL = localNode
 export const STACKS_API_V2_INFO = `${STACKS_API_URL}/v2/info`;
 export const STACKS_API_ACCOUNTS_URL = `${STACKS_API_URL}/v2/accounts`;
 export const STACKS_API_FEE_URL = `${STACKS_API_URL}/v2/fees/transfer`;
+export const TESTNET_FAUCET_URL = 'https://explorer.stacks.co/sandbox/faucet';
 
 export const NETWORK = mainnet ? new StacksMainnet() : new StacksTestnet();
 NETWORK.coreApiUrl = STACKS_API_URL;


### PR DESCRIPTION
[This pr attempts to provide a solution to issue [#51](https://github.com/citycoins/citycoin-ui/issues/51). 

When connected to Testnet, a link appears to the TestNet Faucet. 
I debated a bit on where to put the link, but inside the Actions drop-down in the User Profile seemed to be a reasonable place. Let me know if we want to make it a bit more prominent. 