### PR TITLE
Add stacking reward claims

### DIFF
--- a/src/components/mining/ClaimMiningRewards.js
+++ b/src/components/mining/ClaimMiningRewards.js
@@ -7,7 +7,7 @@ import LoadingSpinner from '../common/LoadingSpinner';
 import { currentStacksBlockAtom, stxAddressAtom } from '../../store/stacks';
 import { CITY_CONFIG, CITY_INFO, currentCityAtom } from '../../store/cities';
 import { canClaimMiningReward, isBlockWinner } from '../../lib/citycoins';
-import { uintCV } from '@stacks/connect/node_modules/@stacks/transactions';
+import { uintCV } from '@stacks/transactions';
 import { STACKS_NETWORK } from '../../lib/stacks';
 
 export default function ClaimMiningRewards() {

--- a/src/components/stacking/ClaimStackingRewards.js
+++ b/src/components/stacking/ClaimStackingRewards.js
@@ -1,10 +1,202 @@
-import ComingSoon from '../common/ComingSoon';
+import { useAtom } from 'jotai';
+import { RESET } from 'jotai/utils';
+import { Fragment, useMemo, useRef, useState } from 'react';
+import { getStackerAtCycle, getStackingReward } from '../../lib/citycoins';
+import {
+  CITY_INFO,
+  currentCityAtom,
+  currentRewardCycleAtom,
+  rewardCyclesToClaimAtom,
+  userIdAtom,
+} from '../../store/cities';
+import { currentStacksBlockAtom } from '../../store/stacks';
+import CurrentRewardCycle from '../common/CurrentRewardCycle';
+import FormResponse from '../common/FormResponse';
+import LoadingSpinner from '../common/LoadingSpinner';
+import StackingReward from './StackingReward';
 
 export default function ClaimStackingRewards() {
+  const [userIds] = useAtom(userIdAtom);
+  const [currentStacksBlock] = useAtom(currentStacksBlockAtom);
+  const [currentRewardCycle] = useAtom(currentRewardCycleAtom);
+  const [currentCity] = useAtom(currentCityAtom);
+  const [rewardCyclesToClaim, setRewardCyclesToClaim] = useAtom(rewardCyclesToClaimAtom);
+  const [loading, setLoading] = useState(false);
+  const [formMsg, setFormMsg] = useState({
+    type: 'light',
+    hidden: true,
+    text: '',
+    txId: '',
+  });
+
+  const symbol = useMemo(() => {
+    return currentCity.loaded ? CITY_INFO[currentCity.data].symbol : undefined;
+  }, [currentCity.loaded, currentCity.data]);
+
+  const rewardCycleRef = useRef();
+
+  const claimPrep = async () => {
+    const cycle = +rewardCycleRef.current.value;
+    // reset state
+    setLoading(true);
+    setFormMsg({
+      type: 'light',
+      hidden: true,
+      text: '',
+      txId: '',
+    });
+    // current stacks block must be loaded
+    if (!currentStacksBlock.loaded) {
+      setFormMsg({
+        type: 'danger',
+        hidden: false,
+        text: 'Stacks block not loaded. Please try again or refresh.',
+      });
+      setLoading(false);
+      return;
+    }
+    // user IDs must be loaded
+    if (!userIds.loaded) {
+      setFormMsg({
+        type: 'danger',
+        hidden: false,
+        text: 'User IDs not loaded. Please try again or refresh.',
+      });
+      setLoading(false);
+      return;
+    }
+    // current reward cycle must be loaded
+    if (!currentRewardCycle.loaded) {
+      setFormMsg({
+        type: 'danger',
+        hidden: false,
+        text: 'Reward cycle not loaded. Please try again or refresh.',
+      });
+      setLoading(false);
+      return;
+    }
+    // no empty values
+    if (cycle === '') {
+      setFormMsg({
+        type: 'danger',
+        hidden: false,
+        text: 'Please enter a reward cycle to claim.',
+      });
+      setLoading(false);
+      return;
+    }
+    // no claiming during/after current cycle
+    if (cycle >= currentRewardCycle.data) {
+      setFormMsg({
+        type: 'danger',
+        hidden: false,
+        text: 'Reward cycle must be before current cycle.',
+      });
+      setLoading(false);
+      return;
+    }
+    // get claim amounts for each version
+    CITY_INFO[currentCity.data].versions.map(async version => {
+      const { stxReward, toReturn } = await getClaimAmounts(cycle, version);
+      // add to array used for display
+      setRewardCyclesToClaim(prev => {
+        let newClaims = { ...prev };
+        // make sure all object keys exist, could
+        // generalize as createNestedObject in common
+        if (!newClaims.hasOwnProperty(currentCity.data)) newClaims[currentCity.data] = {};
+        if (!newClaims[currentCity.data].hasOwnProperty(cycle))
+          newClaims[currentCity.data][cycle] = {};
+        if (!newClaims[currentCity.data][cycle].hasOwnProperty(version))
+          newClaims[currentCity.data][cycle][version] = {};
+        // add new value to existing
+        let newClaimsValue = { ...newClaims };
+
+        newClaimsValue[currentCity.data][cycle][version] = {
+          stxReward: stxReward,
+          toReturn: toReturn,
+        };
+        return newClaimsValue;
+      });
+    });
+    setFormMsg({
+      type: 'success',
+      hidden: false,
+      text: `Reward cycle ${cycle} data loading below.`,
+    });
+    setLoading(false);
+  };
+
+  const getClaimAmounts = async (cycle, version) => {
+    let stxReward = 0;
+    let toReturn = 0;
+    // check if ID is found with version
+    const id = userIds.data[currentCity.data][version] ?? undefined;
+    if (id) {
+      // get reward amount
+      stxReward = await getStackingReward(version, currentCity.data, cycle, id);
+      // get CityCoins to return
+      const stacker = await getStackerAtCycle(version, currentCity.data, cycle, id);
+      toReturn = stacker.toReturn;
+    }
+    return { stxReward: stxReward, toReturn: toReturn };
+  };
+
   return (
     <div className="container-fluid p-6 mb-3">
-      <h3>Claim Stacking Rewards</h3>
-      <ComingSoon />
+      <h3>
+        {`Claim ${symbol ? symbol + ' ' : ''}Stacking Rewards`}{' '}
+        <a
+          className="primary-link"
+          target="_blank"
+          rel="noreferrer"
+          href="https://docs.citycoins.co/core-protocol/stacking-citycoins"
+        >
+          <i className="bi bi-question-circle"></i>
+        </a>
+      </h3>
+      <CurrentRewardCycle />
+      <p>
+        When a reward cycle is complete, Stackers can claim their portion of the STX committed by
+        miners.
+      </p>
+      <p>
+        When the last selected cycle is complete, Stackers can claim their {symbol} back in the same
+        transaction.
+      </p>
+      <form>
+        <div className="form-floating">
+          <input
+            className="form-control"
+            placeholder="Check Reward Cycle"
+            ref={rewardCycleRef}
+            id="rewardCycleRef"
+          />
+          <label htmlFor="rewardCycleRef">Reward Cycle to Check?</label>
+        </div>
+        <button className="btn btn-block btn-primary my-3 me-3" type="button" onClick={claimPrep}>
+          {loading ? <LoadingSpinner text="Check Reward Cycle" /> : 'Check Reward Cycle'}
+        </button>
+        <button
+          className="btn btn-block btn-primary my-3"
+          type="button"
+          onClick={() => setRewardCyclesToClaim(RESET)}
+        >
+          Clear Data
+        </button>
+      </form>
+      <FormResponse {...formMsg} />
+      {rewardCyclesToClaim[currentCity.data] &&
+        Object.values(rewardCyclesToClaim[currentCity.data]).map((cycleData, cycleIndex) => {
+          return Object.values(cycleData).map((versionData, versionIndex) => {
+            const cycle = Object.keys(rewardCyclesToClaim[currentCity.data])[cycleIndex];
+            const version = Object.keys(cycleData)[versionIndex];
+            return (
+              <Fragment key={`${currentCity.data}-${cycle}-${version}`}>
+                <StackingReward version={version} cycle={cycle} data={versionData} />
+              </Fragment>
+            );
+          });
+        })}
     </div>
   );
 }

--- a/src/components/stacking/StackingReward.js
+++ b/src/components/stacking/StackingReward.js
@@ -1,0 +1,110 @@
+import { useConnect } from '@stacks/connect-react';
+import { useAtom } from 'jotai';
+import { useMemo, useState } from 'react';
+import { fromMicro, STACKS_NETWORK } from '../../lib/stacks';
+import { uintCV } from '@stacks/transactions';
+import {
+  CITY_CONFIG,
+  CITY_INFO,
+  currentCityAtom,
+  rewardCyclesToClaimAtom,
+} from '../../store/cities';
+import LinkTx from '../common/LinkTx';
+
+export default function StackingReward({ cycle, version, data }) {
+  const { doContractCall } = useConnect();
+  const [currentCity] = useAtom(currentCityAtom);
+  const [, setRewardCyclesToClaim] = useAtom(rewardCyclesToClaimAtom);
+  const [submitted, setSubmitted] = useState(false);
+  const [txId, setTxId] = useState(undefined);
+
+  const symbol = useMemo(() => {
+    return currentCity.loaded ? CITY_INFO[currentCity.data].symbol : undefined;
+  }, [currentCity.loaded, currentCity.data]);
+
+  const claimReward = async () => {
+    const targetCycleCV = uintCV(cycle);
+    await doContractCall({
+      contractAddress: CITY_CONFIG[currentCity.data][version].deployer,
+      contractName: CITY_CONFIG[currentCity.data][version].core.name,
+      functionName: 'claim-stacking-reward',
+      functionArgs: [targetCycleCV],
+      network: STACKS_NETWORK,
+      onCancel: () => {
+        setSubmitted(false);
+        setTxId(undefined);
+      },
+      onFinish: result => {
+        setSubmitted(true);
+        setTxId(result.txId);
+      },
+    });
+  };
+
+  const removeFromList = async () => {
+    setRewardCyclesToClaim(prev => {
+      const newClaims = { ...prev };
+      delete newClaims[currentCity.data][cycle][version];
+      return newClaims;
+    });
+  };
+
+  return (
+    <>
+      <div className="row text-nowrap text-center">
+        <div className="col">
+          <span className="h5">{cycle}</span>
+          <br />
+          <span className="text-muted">Cycle #</span>
+        </div>
+        <div className="col">
+          <span className="h5">{version}</span>
+          <br />
+          <span className="text-muted">Version</span>
+        </div>
+        <div className="col">
+          <span className="h5">{fromMicro(data.stxReward).toLocaleString()}</span>
+          <br />
+          <span className="text-muted">STX Reward</span>
+        </div>
+        <div className="col">
+          <span className="h5">
+            {version === 'v1'
+              ? data.toReturn.toLocaleString()
+              : fromMicro(data.toReturn).toLocaleString()}
+          </span>
+          <br />
+          <span className="text-muted">{symbol} Returned</span>
+        </div>
+        <div className="col">
+          {data.stxReward > 0 || data.toReturn > 0 ? (
+            submitted && txId ? (
+              <>
+                <LinkTx txId={txId} />
+                <br />
+                <span className="text-muted">Claim</span>
+              </>
+            ) : (
+              <button
+                className="btn btn-block btn-primary"
+                type="button"
+                onClick={claimReward}
+                disabled={submitted}
+              >
+                Claim
+              </button>
+            )
+          ) : (
+            ''
+          )}
+        </div>
+        <div className="col">
+          <button className="btn btn-block" type="button" onClick={removeFromList}>
+            <i className="bi bi-x-circle" />
+          </button>
+        </div>
+      </div>
+      <hr className="cc-divider" />
+    </>
+  );
+}

--- a/src/lib/citycoins.js
+++ b/src/lib/citycoins.js
@@ -109,3 +109,27 @@ export const canClaimMiningReward = async (version, city, block, address) => {
     return undefined;
   }
 };
+
+// https://api.citycoins.co/{version}/{cityname}/stacking/get-stacker-at-cycle/{cycleid}/{userid}/{default}
+export const getStackerAtCycle = async (version, city, cycle, userId) => {
+  const url = `${CC_API_BASE}/${version}/${city}/stacking/get-stacker-at-cycle/${cycle}/${userId}/true`;
+  try {
+    const result = await fetchJson(url);
+    return result;
+  } catch (err) {
+    debugLog(`getStackerAtCycle: ${err}`);
+    return undefined;
+  }
+};
+
+// https://api.citycoins.co/{version}/{cityname}/stacking-claims/get-stacking-reward/{cycleid}/{userid}
+export const getStackingReward = async (version, city, cycle, userId) => {
+  const url = `${CC_API_BASE}/${version}/${city}/stacking-claims/get-stacking-reward/${cycle}/${userId}`;
+  try {
+    const result = await fetchJson(url);
+    return result.value;
+  } catch (err) {
+    debugLog(`getStackingReward: ${err}`);
+    return undefined;
+  }
+};

--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -23,3 +23,22 @@ export const fetchJson = async url => {
   }
   throw new Error(`fetchJson: ${url} ${response.status} ${response.statusText}`);
 };
+
+// helper to create a dynamically nested object
+// credit: https://gist.github.com/brianswisher/2ce1ffe3ec08634f78aacd1b7baa31f9
+// modified and didn't work first time around but pattern in
+// setRewardCyclesToClaim() is a good reference/test
+export const createNestedObject = (keys, data) => {
+  const result = {};
+
+  const lastIndex = keys.length - 1;
+
+  keys.reduce((o, k, i) => {
+    const isLastIndex = i === lastIndex;
+    console.log(`i: ${i} lastIndex: ${lastIndex} isLastIndex: ${isLastIndex}`);
+    const val = isLastIndex ? o[k] : data;
+    return (o[k] = val);
+  }, result);
+
+  return result;
+};

--- a/src/store/cities.js
+++ b/src/store/cities.js
@@ -49,6 +49,23 @@ export const stackingStatsPerCityAtom = atomWithStorage('stackingStatsPerCity', 
   },
 });
 
+// reward cycle claim object
+// expected structure
+// {
+//   "mia": {
+//     "17": {
+//      "v1": {
+//        stxReward: 0,
+//        toReturn: 0,
+//        }
+//     }
+// }
+//
+//
+//
+// }
+export const rewardCyclesToClaimAtom = atomWithStorage('rewardCyclesToClaim', {});
+
 // custom city info object with settings
 // specific to the UI and space to add
 // more properties as needed


### PR DESCRIPTION
This PR adds the stacking rewards claim component, which:

- allows a user to search for a cycle
- searches both V1 and V2 for results
- displays a claim button and shows txid with results
- otherwise displays a blank row w/ 0 values
- rows can be deleted or queried again

Hoping this will help people claim past/future cycles, and the patterns here are useful for building similar information/objects in other components.