### PR TITLE
Add v1 to v2 conversion on full profile

### DIFF
--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -1,6 +1,6 @@
 export default function Footer() {
   return (
-    <footer className="container text-center border-top mt-3 py-3">
+    <footer className="container text-center mt-3 py-3">
       <div className="row">
         <div className="col-md">
           <a

--- a/src/components/profile/CityCoinBalance.js
+++ b/src/components/profile/CityCoinBalance.js
@@ -1,19 +1,87 @@
-export default function CityCoinBalance({ balance, symbol, version }) {
+import { useConnect } from '@stacks/connect-react';
+import {
+  createAssetInfo,
+  FungibleConditionCode,
+  makeStandardFungiblePostCondition,
+  PostConditionMode,
+  uintCV,
+} from '@stacks/transactions';
+import { useAtom } from 'jotai';
+import { useState } from 'react';
+import { fromMicro, STACKS_NETWORK } from '../../lib/stacks';
+import { CITY_CONFIG } from '../../store/cities';
+import { stxAddressAtom } from '../../store/stacks';
+import LinkTx from '../common/LinkTx';
+
+export default function CityCoinBalance({ balances, symbol, version }) {
+  const { doContractCall } = useConnect();
+  const [stxAddress] = useAtom(stxAddressAtom);
+  const [submitted, setSubmitted] = useState(false);
+  const [txId, setTxId] = useState(undefined);
+
+  const convertCityCoins = async () => {
+    const balance = balances.data[symbol][version];
+    const amountCityCoinsCV = uintCV(balance);
+
+    let postConditions = [];
+    balance > 0 &&
+      postConditions.push(
+        makeStandardFungiblePostCondition(
+          stxAddress.data,
+          FungibleConditionCode.Equal,
+          amountCityCoinsCV.value,
+          createAssetInfo(
+            CITY_CONFIG[symbol][version].deployer,
+            CITY_CONFIG[symbol][version].token.name,
+            CITY_CONFIG[symbol][version].token.tokenName
+          )
+        )
+      );
+    await doContractCall({
+      contractAddress: CITY_CONFIG[symbol]['v2'].deployer,
+      contractName: CITY_CONFIG[symbol]['v2'].token.name,
+      functionName: 'convert-to-v2',
+      functionArgs: [],
+      postConditionMode: PostConditionMode.Deny,
+      postConditions: postConditions,
+      network: STACKS_NETWORK,
+      onCancel: () => {
+        setSubmitted(false);
+        setTxId(undefined);
+      },
+      onFinish: result => {
+        setSubmitted(true);
+        setTxId(result.txId);
+      },
+    });
+  };
+
   return (
     <div className="row align-items-center">
-      <div className="col-4 text-nowrap text-right">{balance}</div>
+      <div className="col-4 text-nowrap text-right">
+        {version === 'v2'
+          ? fromMicro(balances.data[symbol][version]).toLocaleString()
+          : balances.data[symbol][version].toLocaleString()}
+      </div>
       <div className="col-4 text-center">
         {symbol.toUpperCase()} ({version})
       </div>
       <div className="col-4 text-center">
-        {version === 'v1' && (
-          <button
-            className="btn btn-sm btn-outline-primary"
-            title={`Convert V1 ${symbol.toUpperCase()} to V2 ${symbol.toUpperCase()}`}
-          >
-            Convert
-          </button>
-        )}
+        {version === 'v1' &&
+          (submitted && txId ? (
+            <small>
+              <LinkTx className="m-3" txId={txId} />
+            </small>
+          ) : (
+            <button
+              className="btn btn-sm btn-outline-primary"
+              title={`Convert V1 ${symbol.toUpperCase()} to V2 ${symbol.toUpperCase()}`}
+              onClick={convertCityCoins}
+              disabled={submitted}
+            >
+              Convert
+            </button>
+          ))}
       </div>
     </div>
   );

--- a/src/components/profile/CityCoinBalance.js
+++ b/src/components/profile/CityCoinBalance.js
@@ -1,0 +1,20 @@
+export default function CityCoinBalance({ balance, symbol, version }) {
+  return (
+    <div className="row align-items-center">
+      <div className="col-4 text-nowrap text-right">{balance}</div>
+      <div className="col-4 text-center">
+        {symbol.toUpperCase()} ({version})
+      </div>
+      <div className="col-4 text-center">
+        {version === 'v1' && (
+          <button
+            className="btn btn-sm btn-outline-primary"
+            title={`Convert V1 ${symbol.toUpperCase()} to V2 ${symbol.toUpperCase()}`}
+          >
+            Convert
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/profile/CityCoinUserIds.js
+++ b/src/components/profile/CityCoinUserIds.js
@@ -5,7 +5,7 @@ export default function CityCoinUserIds({ userId, city, version }) {
       <div className="col-4 text-center">
         {city.toUpperCase()} ({version})
       </div>
-      <div class="w-100"></div>
+      <div className="w-100"></div>
     </div>
   );
 }

--- a/src/components/profile/CityCoinUserIds.js
+++ b/src/components/profile/CityCoinUserIds.js
@@ -1,0 +1,11 @@
+export default function CityCoinUserIds({ userId, city, version }) {
+  return (
+    <div className="row align-items-center">
+      <div className="col-4 text-right text-nowrap">{userId}</div>
+      <div className="col-4 text-center">
+        {city.toUpperCase()} ({version})
+      </div>
+      <div class="w-100"></div>
+    </div>
+  );
+}

--- a/src/components/profile/ProfileFull.js
+++ b/src/components/profile/ProfileFull.js
@@ -7,6 +7,9 @@ import { useConnect } from '../../lib/auth';
 import { fromMicro, isTestnet, TESTNET_FAUCET_URL } from '../../lib/stacks';
 import { loginStatusAtom, stxAddressAtom, userBalancesAtom } from '../../store/stacks';
 import { userIdAtom } from '../../store/cities';
+import CityCoinBalance from './CityCoinBalance';
+import StxBalance from './StxBalance';
+import CityCoinUserIds from './CityCoinUserIds';
 
 export function ProfileFull() {
   const [loginStatus] = useAtom(loginStatusAtom);
@@ -85,73 +88,56 @@ export function ProfileFull() {
             </button>
           </div>
           <h4 className="text-center mt-3">Account Balances</h4>
-          <div className="row align-items-center">
-            {balances.loaded ? (
-              Object.keys(balances.data).map(key => {
-                return typeof balances.data[key] === 'object' ? (
-                  Object.keys(balances.data[key]).map(key2 => {
-                    return (
-                      <Fragment key={`${key}-${key2}-container`}>
-                        <div className="col-4 text-nowrap text-right">
-                          {key2 === 'v2'
-                            ? fromMicro(balances.data[key][key2]).toLocaleString()
-                            : balances.data[key][key2].toLocaleString()}
-                        </div>
-                        <div className="col-4 text-center">
-                          {key.toUpperCase()} ({key2})
-                        </div>
-                        <div className="col-4 text-center">
-                          {key2 === 'v1' && (
-                            <button
-                              className="btn btn-sm btn-outline-primary"
-                              title={`Convert V1 ${key.toUpperCase()} to V2 ${key.toUpperCase()}`}
-                            >
-                              Convert
-                            </button>
-                          )}
-                        </div>
-                        <hr className="cc-divider-alt" />
-                      </Fragment>
-                    );
-                  })
-                ) : (
-                  <Fragment key={`${key}-container`}>
-                    <div className="col-4 text-nowrap text-right">
-                      {fromMicro(balances.data[key]).toLocaleString()}
-                    </div>
-                    <div className="col-4 text-center">{key.toUpperCase()}</div>
-                    <div class="w-100"></div>
-                    <hr className="cc-divider-alt" />
-                  </Fragment>
-                );
-              })
-            ) : (
-              <LoadingSpinner text="Loading balances..." />
-            )}
-            <h4 className="text-center mt-3">CityCoin User IDs</h4>
-            {userIds.loaded ? (
-              Object.keys(userIds.data).map(key => {
-                return Object.keys(userIds.data[key]).map(key2 => {
+          {balances.loaded ? (
+            Object.keys(balances.data).map(symbol => {
+              return typeof balances.data[symbol] === 'object' ? (
+                Object.keys(balances.data[symbol]).map(version => {
                   return (
-                    <Fragment key={`${key}-${key2}-container`}>
-                      <div className="col-4 text-right text-nowrap">
-                        {userIds.data[key][key2]
-                          ? userIds.data[key][key2].toLocaleString()
-                          : 'None'}
-                      </div>
-                      <div className="col-4 text-center">
-                        {key.toUpperCase()} ({key2})
-                      </div>
-                      <div class="w-100"></div>
-                      <hr className="cc-divider-alt" />
-                    </Fragment>
+                    <CityCoinBalance
+                      key={`${symbol}-${version}-container`}
+                      balance={
+                        version === 'v2'
+                          ? fromMicro(balances.data[symbol][version]).toLocaleString()
+                          : balances.data[symbol][version].toLocaleString()
+                      }
+                      symbol={symbol}
+                      version={version}
+                    />
                   );
-                });
-              })
-            ) : (
-              <LoadingSpinner text="Loading user IDs..." />
-            )}
-          </div>
+                })
+              ) : (
+                <StxBalance
+                  key={`${symbol}-container`}
+                  balance={fromMicro(balances.data[symbol]).toLocaleString()}
+                  symbol={symbol}
+                />
+              );
+            })
+          ) : (
+            <LoadingSpinner text="Loading balances..." />
+          )}
+          <hr className="cc-divider" />
+          <h4 className="text-center mt-3">CityCoin User IDs</h4>
+          {userIds.loaded ? (
+            Object.keys(userIds.data).map(city => {
+              return Object.keys(userIds.data[city]).map(version => {
+                return (
+                  <CityCoinUserIds
+                    key={`${city}-${version}-container`}
+                    userId={
+                      userIds.data[city][version]
+                        ? userIds.data[city][version].toLocaleString()
+                        : 'None'
+                    }
+                    city={city}
+                    version={version}
+                  />
+                );
+              });
+            })
+          ) : (
+            <LoadingSpinner text="Loading user IDs..." />
+          )}
         </div>
       </div>
     );

--- a/src/components/profile/ProfileFull.js
+++ b/src/components/profile/ProfileFull.js
@@ -1,4 +1,3 @@
-import { Fragment } from 'react';
 import { useAtom } from 'jotai';
 import { Address } from './Address';
 import { NetworkIndicatorIcon } from './NetworkIndicatorIcon';
@@ -95,11 +94,7 @@ export function ProfileFull() {
                   return (
                     <CityCoinBalance
                       key={`${symbol}-${version}-container`}
-                      balance={
-                        version === 'v2'
-                          ? fromMicro(balances.data[symbol][version]).toLocaleString()
-                          : balances.data[symbol][version].toLocaleString()
-                      }
+                      balances={balances}
                       symbol={symbol}
                       version={version}
                     />

--- a/src/components/profile/ProfileFull.js
+++ b/src/components/profile/ProfileFull.js
@@ -91,14 +91,14 @@ export function ProfileFull() {
             Object.keys(balances.data).map(symbol => {
               return typeof balances.data[symbol] === 'object' ? (
                 Object.keys(balances.data[symbol]).map(version => {
-                  return (
+                  return balances.data[symbol][version] > 0 ? (
                     <CityCoinBalance
                       key={`${symbol}-${version}-container`}
                       balances={balances}
                       symbol={symbol}
                       version={version}
                     />
-                  );
+                  ) : null;
                 })
               ) : (
                 <StxBalance

--- a/src/components/profile/ProfileFull.js
+++ b/src/components/profile/ProfileFull.js
@@ -84,53 +84,66 @@ export function ProfileFull() {
               <i className="bi bi-x-circle"></i>
             </button>
           </div>
-          <hr className="cc-divider" />
-          <h4 className="text-center">Account Balances</h4>
-          <div className="row">
+          <h4 className="text-center mt-3">Account Balances</h4>
+          <div className="row align-items-center">
             {balances.loaded ? (
               Object.keys(balances.data).map(key => {
                 return typeof balances.data[key] === 'object' ? (
                   Object.keys(balances.data[key]).map(key2 => {
                     return (
                       <Fragment key={`${key}-${key2}-container`}>
-                        <div className="col-6 text-right text-nowrap">
+                        <div className="col-4 text-nowrap text-right">
                           {key2 === 'v2'
                             ? fromMicro(balances.data[key][key2]).toLocaleString()
                             : balances.data[key][key2].toLocaleString()}
                         </div>
-                        <div className="col-6">
-                          {key2.toUpperCase()} {key.toUpperCase()}
+                        <div className="col-4 text-center">
+                          {key.toUpperCase()} ({key2})
                         </div>
+                        <div className="col-4 text-center">
+                          {key2 === 'v1' && (
+                            <button
+                              className="btn btn-sm btn-outline-primary"
+                              title={`Convert V1 ${key.toUpperCase()} to V2 ${key.toUpperCase()}`}
+                            >
+                              Convert
+                            </button>
+                          )}
+                        </div>
+                        <hr className="cc-divider-alt" />
                       </Fragment>
                     );
                   })
                 ) : (
                   <Fragment key={`${key}-container`}>
-                    <div className="col-6 text-right text-nowrap">
+                    <div className="col-4 text-nowrap text-right">
                       {fromMicro(balances.data[key]).toLocaleString()}
                     </div>
-                    <div className="col-6">{key.toUpperCase()}</div>
+                    <div className="col-4 text-center">{key.toUpperCase()}</div>
+                    <div class="w-100"></div>
+                    <hr className="cc-divider-alt" />
                   </Fragment>
                 );
               })
             ) : (
               <LoadingSpinner text="Loading balances..." />
             )}
-            <hr className="cc-divider" />
-            <h4 className="text-center">CityCoin User IDs</h4>
+            <h4 className="text-center mt-3">CityCoin User IDs</h4>
             {userIds.loaded ? (
               Object.keys(userIds.data).map(key => {
                 return Object.keys(userIds.data[key]).map(key2 => {
                   return (
                     <Fragment key={`${key}-${key2}-container`}>
-                      <div className="col-6 text-right text-nowrap">
+                      <div className="col-4 text-right text-nowrap">
                         {userIds.data[key][key2]
                           ? userIds.data[key][key2].toLocaleString()
                           : 'None'}
                       </div>
-                      <div className="col-6">
-                        {key2.toUpperCase()} {key.toUpperCase()}
+                      <div className="col-4 text-center">
+                        {key.toUpperCase()} ({key2})
                       </div>
+                      <div class="w-100"></div>
+                      <hr className="cc-divider-alt" />
                     </Fragment>
                   );
                 });

--- a/src/components/profile/StxBalance.js
+++ b/src/components/profile/StxBalance.js
@@ -3,7 +3,7 @@ export default function StxBalance({ balance, symbol }) {
     <div className="row align-items-center">
       <div className="col-4 text-nowrap text-right">{balance}</div>
       <div className="col-4 text-center">{symbol.toUpperCase()}</div>
-      <div class="w-100"></div>
+      <div className="w-100"></div>
     </div>
   );
 }

--- a/src/components/profile/StxBalance.js
+++ b/src/components/profile/StxBalance.js
@@ -1,0 +1,9 @@
+export default function StxBalance({ balance, symbol }) {
+  return (
+    <div className="row align-items-center">
+      <div className="col-4 text-nowrap text-right">{balance}</div>
+      <div className="col-4 text-center">{symbol.toUpperCase()}</div>
+      <div class="w-100"></div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a button on the profile tab that makes a contract call to convert V1 to V2 tokens when detected.

It also updates the profile to not display a token if it has no balance, and moves any repeated/mapped elements into individual components.