### PR TITLE
Add stacking form

### DIFF
--- a/src/components/stacking/StackCityCoins.js
+++ b/src/components/stacking/StackCityCoins.js
@@ -1,10 +1,216 @@
-import ComingSoon from '../common/ComingSoon';
+import { useConnect } from '@stacks/connect-react';
+import { uintCV } from '@stacks/transactions';
+import { useAtom } from 'jotai';
+import { useMemo, useRef, useState } from 'react';
+import { isStringAllDigits } from '../../lib/common';
+import { fromMicro, STACKS_NETWORK } from '../../lib/stacks';
+import {
+  CITY_CONFIG,
+  CITY_INFO,
+  currentCityAtom,
+  currentRewardCycleAtom,
+  stackingStatsPerCityAtom,
+} from '../../store/cities';
+import { userBalancesAtom } from '../../store/stacks';
+import CurrentRewardCycle from '../common/CurrentRewardCycle';
+import FormResponse from '../common/FormResponse';
+import LoadingSpinner from '../common/LoadingSpinner';
+import StackingStats from '../dashboard/StackingStats';
 
 export default function StackCityCoins() {
+  const { doContractCall } = useConnect();
+
+  const [currentRewardCycle] = useAtom(currentRewardCycleAtom);
+  const [currentCity] = useAtom(currentCityAtom);
+  const [stackingStatsPerCity] = useAtom(stackingStatsPerCityAtom);
+  const [balances] = useAtom(userBalancesAtom);
+
+  const [loading, setLoading] = useState(false);
+  const [formMsg, setFormMsg] = useState({
+    type: 'light',
+    hidden: true,
+    text: '',
+    txId: '',
+  });
+
+  const amountRef = useRef();
+  const cyclesRef = useRef();
+
+  const symbol = useMemo(() => {
+    return currentCity.loaded ? CITY_INFO[currentCity.data].symbol : undefined;
+  }, [currentCity.loaded, currentCity.data]);
+
+  const cityStackingStats = useMemo(() => {
+    if (currentCity.loaded) {
+      const key = currentCity.data;
+      if (stackingStatsPerCity[key]) {
+        return stackingStatsPerCity[key];
+      }
+    }
+    return undefined;
+  }, [currentCity.loaded, currentCity.data, stackingStatsPerCity]);
+
+  const stackingPrep = async () => {
+    const amount = +amountRef.current.value;
+    const cycles = +cyclesRef.current.value;
+    // reset state
+    setLoading(true);
+    setFormMsg({
+      type: 'light',
+      hidden: true,
+      text: '',
+      txId: '',
+    });
+    // check if amount is valid
+    if (isNaN(amount) || !isStringAllDigits(amount) || amount <= 0) {
+      setFormMsg({
+        type: 'danger',
+        hidden: false,
+        text: `Please enter a valid amount to stack.${
+          balances.loaded
+            ? ' Current balance: ' +
+              fromMicro(balances.data[currentCity.data]['v2']).toLocaleString(undefined, {
+                minimumFractionDigits: 6,
+                maximumFractionDigits: 6,
+              }) +
+              ' ' +
+              symbol
+            : ''
+        }.`,
+      });
+      setLoading(false);
+      return;
+    }
+    // check if cycles are valid
+    if (isNaN(cycles) || !isStringAllDigits(cycles) || cycles <= 0 || cycles > 32) {
+      setFormMsg({
+        type: 'danger',
+        hidden: false,
+        text: 'Please enter a valid number of cycles (1-32).',
+      });
+      setLoading(false);
+      return;
+    }
+    await stack(amount, cycles);
+  };
+
+  const stack = async (amount, cycles) => {
+    const amountCV = uintCV(amount);
+    const cyclesCV = uintCV(cycles);
+    const version = CITY_INFO[currentCity.data].currentVersion;
+    await doContractCall({
+      contractAddress: CITY_CONFIG[currentCity.data][version].deployer,
+      contractName: CITY_CONFIG[currentCity.data][version].core.name,
+      functionName: 'stack-tokens',
+      functionArgs: [amountCV, cyclesCV],
+      network: STACKS_NETWORK,
+      onCancel: () => {
+        setLoading(false);
+        setFormMsg({
+          type: 'warning',
+          hidden: false,
+          text: 'Transaction was canceled, please try again.',
+        });
+      },
+      onFinish: result => {
+        setLoading(false);
+        setFormMsg({
+          type: 'success',
+          hidden: false,
+          text: `Stacking transaction successfully sent.`,
+          txId: result.txId,
+        });
+      },
+    });
+  };
+
   return (
     <div className="container-fluid p-6">
-      <h3>Stack CityCoins</h3>
-      <ComingSoon />
+      <h3>
+        {`Stacking ${symbol ? symbol : 'CityCoins'}`}{' '}
+        <a
+          className="primary-link"
+          target="_blank"
+          rel="noreferrer"
+          href="https://docs.citycoins.co/core-protocol/stacking-citycoins"
+        >
+          <i className="bi bi-question-circle"></i>
+        </a>
+      </h3>
+      <CurrentRewardCycle symbol={symbol} />
+      <p>
+        Stacking CityCoins locks up {symbol} in the contract for a selected number of reward cycles
+        in return for a portion of the STX sent by miners.
+      </p>
+      <p>
+        For more information on Stacking, please read the{' '}
+        <a
+          href="https://docs.citycoins.co/citycoins-core-protocol/stacking-citycoins#common-questions"
+          target="_blank"
+          rel="noreferrer"
+        >
+          common questions in the documentation
+        </a>
+        .
+      </p>
+      {cityStackingStats.updating ? (
+        <LoadingSpinner text={`Loading stacking data`} />
+      ) : (
+        cityStackingStats.data.map(value => (
+          <StackingStats key={`stats-${value.cycle}`} stats={value} />
+        ))
+      )}
+      <div class="row flex-col bg-secondary rounded-3 p-3 mt-3">
+        <div class="col-lg-6">
+          <p className="fw-bold mt-3">Some quick notes:</p>
+          <ul>
+            <li>{symbol} are transferred to the contract while Stacking</li>
+            <li>STX rewards can be claimed after each cycle ends</li>
+            <li>Stacked {symbol} can be claimed after the selected period ends</li>
+            <li>
+              Stacking always occurs in the <span className="fst-italic">next reward cycle</span>
+            </li>
+            <li>Stackers must skip one cycle after the selected period ends</li>
+          </ul>
+        </div>
+        <div class="col">
+          <h4 className="mt-3">{`Stack ${symbol} in Cycle ${currentRewardCycle.data + 1}`}</h4>
+          <form>
+            <div className="input-group mb-3">
+              <input
+                type="number"
+                className="form-control"
+                ref={amountRef}
+                aria-label={`Amount in ${symbol}`}
+                placeholder={`Amount in ${symbol}`}
+                required
+                minLength="1"
+              />
+              <span className="input-group-text">{symbol}</span>
+              <button className="btn btn-sm btn-primary ms-3" type="button">
+                MAX
+              </button>
+            </div>
+            <div className="input-group mb-3">
+              <input
+                type="number"
+                className="form-control"
+                ref={cyclesRef}
+                aria-label="Number of Reward Cycles"
+                placeholder="Number of Reward Cycles"
+                required
+                max="32"
+                minLength="1"
+              />
+            </div>
+            <button className="btn btn-block btn-primary" type="button" onClick={stackingPrep}>
+              {loading ? <LoadingSpinner text="Stacking..." /> : 'Stack'}
+            </button>
+          </form>
+          <br />
+          <FormResponse {...formMsg} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/stacking/StackCityCoins.js
+++ b/src/components/stacking/StackCityCoins.js
@@ -1,9 +1,15 @@
 import { useConnect } from '@stacks/connect-react';
-import { uintCV } from '@stacks/transactions';
+import {
+  createAssetInfo,
+  FungibleConditionCode,
+  makeStandardFungiblePostCondition,
+  PostConditionMode,
+  uintCV,
+} from '@stacks/transactions';
 import { useAtom } from 'jotai';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { isStringAllDigits } from '../../lib/common';
-import { fromMicro, STACKS_NETWORK } from '../../lib/stacks';
+import { fromMicro, STACKS_NETWORK, toMicro } from '../../lib/stacks';
 import {
   CITY_CONFIG,
   CITY_INFO,
@@ -11,7 +17,7 @@ import {
   currentRewardCycleAtom,
   stackingStatsPerCityAtom,
 } from '../../store/cities';
-import { userBalancesAtom } from '../../store/stacks';
+import { stxAddressAtom, userBalancesAtom } from '../../store/stacks';
 import CurrentRewardCycle from '../common/CurrentRewardCycle';
 import FormResponse from '../common/FormResponse';
 import LoadingSpinner from '../common/LoadingSpinner';
@@ -20,6 +26,7 @@ import StackingStats from '../dashboard/StackingStats';
 export default function StackCityCoins() {
   const { doContractCall } = useConnect();
 
+  const [stxAddress] = useAtom(stxAddressAtom);
   const [currentRewardCycle] = useAtom(currentRewardCycleAtom);
   const [currentCity] = useAtom(currentCityAtom);
   const [stackingStatsPerCity] = useAtom(stackingStatsPerCityAtom);
@@ -50,6 +57,19 @@ export default function StackCityCoins() {
     return undefined;
   }, [currentCity.loaded, currentCity.data, stackingStatsPerCity]);
 
+  useEffect(() => {
+    // reset state
+    setLoading(false);
+    setFormMsg({
+      type: 'light',
+      hidden: true,
+      text: '',
+      txId: '',
+    });
+    amountRef.current.value = undefined;
+    cyclesRef.current.value = undefined;
+  }, [currentCity.data]);
+
   const stackingPrep = async () => {
     const amount = +amountRef.current.value;
     const cycles = +cyclesRef.current.value;
@@ -61,22 +81,24 @@ export default function StackCityCoins() {
       text: '',
       txId: '',
     });
-    // check if amount is valid
-    if (isNaN(amount) || !isStringAllDigits(amount) || amount <= 0) {
+    // check if balances are loaded
+    if (!balances.loaded) {
       setFormMsg({
         type: 'danger',
         hidden: false,
-        text: `Please enter a valid amount to stack.${
-          balances.loaded
-            ? ' Current balance: ' +
-              fromMicro(balances.data[currentCity.data]['v2']).toLocaleString(undefined, {
-                minimumFractionDigits: 6,
-                maximumFractionDigits: 6,
-              }) +
-              ' ' +
-              symbol
-            : ''
-        }.`,
+        text: 'Balances not loaded. Please try again or refresh.',
+      });
+      return;
+    }
+    // check if amount is valid
+    const balance = +balances.data[currentCity.data]['v2'];
+    if (isNaN(amount) || !isStringAllDigits(amount) || amount <= 0 || toMicro(amount) > balance) {
+      setFormMsg({
+        type: 'danger',
+        hidden: false,
+        text: `Please enter a valid amount to stack. Current balance: ${fromMicro(
+          balances.data[currentCity.data]['v2']
+        ).toLocaleString()} ${symbol}`,
       });
       setLoading(false);
       return;
@@ -91,11 +113,21 @@ export default function StackCityCoins() {
       setLoading(false);
       return;
     }
+    // stx address must be loaded
+    if (!stxAddress.loaded) {
+      setFormMsg({
+        type: 'danger',
+        hidden: false,
+        text: 'Stacks address not loaded. Please try again or refresh.',
+      });
+      setLoading(false);
+      return;
+    }
     await stack(amount, cycles);
   };
 
   const stack = async (amount, cycles) => {
-    const amountCV = uintCV(amount);
+    const amountCV = uintCV(toMicro(amount));
     const cyclesCV = uintCV(cycles);
     const version = CITY_INFO[currentCity.data].currentVersion;
     await doContractCall({
@@ -104,6 +136,19 @@ export default function StackCityCoins() {
       functionName: 'stack-tokens',
       functionArgs: [amountCV, cyclesCV],
       network: STACKS_NETWORK,
+      postConditionMode: PostConditionMode.Deny,
+      postConditions: [
+        makeStandardFungiblePostCondition(
+          stxAddress.data,
+          FungibleConditionCode.Equal,
+          amountCV.value,
+          createAssetInfo(
+            CITY_CONFIG[currentCity.data][version].deployer,
+            CITY_CONFIG[currentCity.data][version].token.name,
+            CITY_CONFIG[currentCity.data][version].token.tokenName
+          )
+        ),
+      ],
       onCancel: () => {
         setLoading(false);
         setFormMsg({
@@ -122,6 +167,18 @@ export default function StackCityCoins() {
         });
       },
     });
+  };
+
+  const max = async () => {
+    if (!balances.loaded) {
+      setFormMsg({
+        type: 'danger',
+        hidden: false,
+        text: 'Balances not loaded. Please try again or refresh.',
+      });
+      return;
+    }
+    amountRef.current.value = fromMicro(balances.data[currentCity.data]['v2']);
   };
 
   return (
@@ -160,55 +217,57 @@ export default function StackCityCoins() {
           <StackingStats key={`stats-${value.cycle}`} stats={value} />
         ))
       )}
-      <div class="row flex-col bg-secondary rounded-3 p-3 mt-3">
-        <div class="col-lg-6">
-          <p className="fw-bold mt-3">Some quick notes:</p>
-          <ul>
-            <li>{symbol} are transferred to the contract while Stacking</li>
-            <li>STX rewards can be claimed after each cycle ends</li>
-            <li>Stacked {symbol} can be claimed after the selected period ends</li>
-            <li>
-              Stacking always occurs in the <span className="fst-italic">next reward cycle</span>
-            </li>
-            <li>Stackers must skip one cycle after the selected period ends</li>
-          </ul>
-        </div>
-        <div class="col">
-          <h4 className="mt-3">{`Stack ${symbol} in Cycle ${currentRewardCycle.data + 1}`}</h4>
-          <form>
-            <div className="input-group mb-3">
-              <input
-                type="number"
-                className="form-control"
-                ref={amountRef}
-                aria-label={`Amount in ${symbol}`}
-                placeholder={`Amount in ${symbol}`}
-                required
-                minLength="1"
-              />
-              <span className="input-group-text">{symbol}</span>
-              <button className="btn btn-sm btn-primary ms-3" type="button">
-                MAX
+      <div class="container-fluid">
+        <div class="row flex-col bg-secondary rounded-3 p-3 mt-3">
+          <div class="col-lg-6">
+            <p className="fs-4 fw-bold mt-3">Some quick notes:</p>
+            <ul>
+              <li>{symbol} are transferred to the contract while Stacking</li>
+              <li>STX rewards can be claimed after each cycle ends</li>
+              <li>Stacked {symbol} can be claimed after the selected period ends</li>
+              <li>
+                Stacking always occurs in the <span className="fst-italic">next reward cycle</span>
+              </li>
+              <li>Stackers must skip one cycle after the selected period ends</li>
+            </ul>
+          </div>
+          <div class="col">
+            <h4 className="mt-3">{`Stack ${symbol} in Cycle ${currentRewardCycle.data + 1}`}</h4>
+            <form>
+              <div className="input-group mb-3">
+                <input
+                  type="number"
+                  className="form-control"
+                  ref={amountRef}
+                  aria-label={`Amount in ${symbol}`}
+                  placeholder={`Amount in ${symbol}`}
+                  required
+                  minLength="1"
+                />
+                <span className="input-group-text">{symbol}</span>
+                <button className="btn btn-sm btn-primary ms-3" type="button" onClick={max}>
+                  MAX
+                </button>
+              </div>
+              <div className="input-group mb-3">
+                <input
+                  type="number"
+                  className="form-control"
+                  ref={cyclesRef}
+                  aria-label="Number of Reward Cycles"
+                  placeholder="Number of Reward Cycles"
+                  required
+                  max="32"
+                  minLength="1"
+                />
+              </div>
+              <button className="btn btn-block btn-primary" type="button" onClick={stackingPrep}>
+                {loading ? <LoadingSpinner text="Stacking..." /> : 'Stack'}
               </button>
-            </div>
-            <div className="input-group mb-3">
-              <input
-                type="number"
-                className="form-control"
-                ref={cyclesRef}
-                aria-label="Number of Reward Cycles"
-                placeholder="Number of Reward Cycles"
-                required
-                max="32"
-                minLength="1"
-              />
-            </div>
-            <button className="btn btn-block btn-primary" type="button" onClick={stackingPrep}>
-              {loading ? <LoadingSpinner text="Stacking..." /> : 'Stack'}
-            </button>
-          </form>
-          <br />
-          <FormResponse {...formMsg} />
+            </form>
+            <br />
+            <FormResponse {...formMsg} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/lib/common.js
+++ b/src/lib/common.js
@@ -24,6 +24,12 @@ export const fetchJson = async url => {
   throw new Error(`fetchJson: ${url} ${response.status} ${response.statusText}`);
 };
 
+// fix for isNaN not being reliable
+export function isStringAllDigits(value) {
+  return value.toString().match(/^[0-9]+$/g) !== null;
+}
+
+// INCOMPLETE
 // helper to create a dynamically nested object
 // credit: https://gist.github.com/brianswisher/2ce1ffe3ec08634f78aacd1b7baa31f9
 // modified and didn't work first time around but pattern in

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -8,6 +8,7 @@
   --brand-text: #000;
   --brand-layer-2: #c4c6c8;
   --brand-layer-1: #d1d3d4;
+  --brand-layer-0: #ebeced;
   --brand-background: #fff;
   /* Triadic and Complementary Variations */
   --brand-info: #30aed9;
@@ -62,7 +63,7 @@ inspect {
 }
 
 .bg-secondary {
-  background-color: var(--brand-layer-1) !important;
+  background-color: var(--brand-layer-0) !important;
   color: var(--brand-text);
 }
 


### PR DESCRIPTION
Adds the Stacking component with a new layout and using the new data structure.

This PR is a good example of how to add a component that makes a contract call based on existing data already loaded in atoms, and re-uses the stacking data loaded on the dashboard.