### PR TITLE
Change "substr" to "substring" in multiple places

### DIFF
--- a/src/components/common/LinkTx.js
+++ b/src/components/common/LinkTx.js
@@ -5,7 +5,7 @@ export default function LinkTx({ txId, shorten = true }) {
   const url = `${STACKS_EXPLORER}/txid/${txId}`;
   return (
     <a href={`${url}${CHAIN_SUFFIX}`} target="_blank" rel="noreferrer">
-      {shorten ? txId.substr(0, 5) + '...' + txId.substr(txId.length - 5) : txId}
+      {shorten ? txId.substring(0, 5) + '...' + txId.substring(txId.length - 5) : txId}
       <i className="bi bi-box-arrow-up-right ms-1" />
     </a>
   );

--- a/src/components/profile/Address.js
+++ b/src/components/profile/Address.js
@@ -8,7 +8,7 @@ export function Address() {
   const displayAddress = useMemo(() => {
     if (bnsName.loaded) return bnsName.data;
     if (stxAddress.loaded)
-      return `${stxAddress.data.substr(0, 5)}...${stxAddress.data.substr(
+      return `${stxAddress.data.substring(0, 5)}...${stxAddress.data.substring(
         stxAddress.data.length - 5
       )}`;
     return 'Profile';


### PR DESCRIPTION
Issue: https://github.com/citycoins/ui/issues/146

Updated the outdated `substr()` method to use the current `substring()` method, as mentioned in the issue description.