### PR TITLE
enhancement: create documentation link component #143

### DIFF
--- a/src/components/activation/RegisterUser.js
+++ b/src/components/activation/RegisterUser.js
@@ -1,9 +1,12 @@
 import ComingSoon from '../common/ComingSoon';
+import DocumentationLink from '../common/DocumentationLink';
 
 export default function RegisterUser() {
   return (
     <div className="container-fluid p-6">
-      <h3>Register User</h3>
+      <h3>{`Register User `}
+        <DocumentationLink docLink="https://docs.citycoins.co/core-protocol/registration-and-activation" />
+      </h3>
       <ComingSoon />
     </div>
   );

--- a/src/components/common/DocumentationLink.js
+++ b/src/components/common/DocumentationLink.js
@@ -1,0 +1,12 @@
+export default function DocumentationLink({ docLink }) {
+    return (
+        <a
+          className="primary-link"
+          target="_blank"
+          rel="noreferrer"
+          href={docLink}
+        >
+          <i className="bi bi-question-circle"></i>
+        </a>
+    )
+}

--- a/src/components/mining/ClaimMiningRewards.js
+++ b/src/components/mining/ClaimMiningRewards.js
@@ -4,6 +4,7 @@ import { useAtom } from 'jotai';
 import CurrentStacksBlock from '../common/CurrentStacksBlock';
 import FormResponse from '../common/FormResponse';
 import LoadingSpinner from '../common/LoadingSpinner';
+import DocumentationLink from '../common/DocumentationLink';
 import { currentStacksBlockAtom, stxAddressAtom } from '../../store/stacks';
 import { CITY_CONFIG, CITY_INFO, currentCityAtom } from '../../store/cities';
 import { canClaimMiningReward, isBlockWinner } from '../../lib/citycoins';
@@ -175,14 +176,7 @@ export default function ClaimMiningRewards() {
     <div className="container-fluid p-6">
       <h3>
         {`Claim ${symbol ? symbol + ' ' : ''}Mining Rewards`}{' '}
-        <a
-          className="primary-link"
-          target="_blank"
-          rel="noreferrer"
-          href="https://docs.citycoins.co/core-protocol/mining-citycoins"
-        >
-          <i className="bi bi-question-circle"></i>
-        </a>
+        <DocumentationLink docLink="https://docs.citycoins.co/core-protocol/mining-citycoins" />
       </h3>
       <CurrentStacksBlock />
       <p>

--- a/src/components/mining/MineCityCoins.js
+++ b/src/components/mining/MineCityCoins.js
@@ -1,9 +1,12 @@
 import ComingSoon from '../common/ComingSoon';
+import DocumentationLink from '../common/DocumentationLink';
 
 export default function MineCityCoins() {
   return (
     <div className="container-fluid p-6">
-      <h3>Mine CityCoins</h3>
+      <h3>{`Mine CityCoins `}
+        <DocumentationLink docLink="https://docs.citycoins.co/core-protocol/mining-citycoins" />
+      </h3>
       <ComingSoon />
     </div>
   );

--- a/src/components/stacking/ClaimStackingRewards.js
+++ b/src/components/stacking/ClaimStackingRewards.js
@@ -13,6 +13,7 @@ import { currentStacksBlockAtom } from '../../store/stacks';
 import CurrentRewardCycle from '../common/CurrentRewardCycle';
 import FormResponse from '../common/FormResponse';
 import LoadingSpinner from '../common/LoadingSpinner';
+import DocumentationLink from '../common/DocumentationLink';
 import StackingReward from './StackingReward';
 
 export default function ClaimStackingRewards() {
@@ -140,14 +141,7 @@ export default function ClaimStackingRewards() {
     <div className="container-fluid p-6 mb-3">
       <h3>
         {`Claim ${symbol ? symbol + ' ' : ''}Stacking Rewards`}{' '}
-        <a
-          className="primary-link"
-          target="_blank"
-          rel="noreferrer"
-          href="https://docs.citycoins.co/core-protocol/stacking-citycoins"
-        >
-          <i className="bi bi-question-circle"></i>
-        </a>
+        <DocumentationLink docLink="https://docs.citycoins.co/core-protocol/stacking-citycoins" />
       </h3>
       <CurrentRewardCycle />
       <p>

--- a/src/components/stacking/StackCityCoins.js
+++ b/src/components/stacking/StackCityCoins.js
@@ -21,6 +21,7 @@ import { stxAddressAtom, userBalancesAtom } from '../../store/stacks';
 import CurrentRewardCycle from '../common/CurrentRewardCycle';
 import FormResponse from '../common/FormResponse';
 import LoadingSpinner from '../common/LoadingSpinner';
+import DocumentationLink from '../common/DocumentationLink';
 import StackingStats from '../dashboard/StackingStats';
 
 export default function StackCityCoins() {
@@ -185,14 +186,7 @@ export default function StackCityCoins() {
     <div className="container-fluid p-6">
       <h3>
         {`Stacking ${symbol ? symbol : 'CityCoins'}`}{' '}
-        <a
-          className="primary-link"
-          target="_blank"
-          rel="noreferrer"
-          href="https://docs.citycoins.co/core-protocol/stacking-citycoins"
-        >
-          <i className="bi bi-question-circle"></i>
-        </a>
+        <DocumentationLink docLink="https://docs.citycoins.co/core-protocol/stacking-citycoins"/>
       </h3>
       <CurrentRewardCycle symbol={symbol} />
       <p>


### PR DESCRIPTION
I refactored the links described in issue 143 as a DocumentationLink component and saved it in the src/components/common directory. I used docLink as the prop to be passed. I also added component to the action-related pages with their corresponding link to the documentation.